### PR TITLE
Fix callable in anticipate

### DIFF
--- a/src/Commands/Concerns/AsksApplication.php
+++ b/src/Commands/Concerns/AsksApplication.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait AsksApplication
 {
+    use WrapsCallable;
+
     /**
      * @param \Illuminate\Support\Collection<int, string> $applications
      */
@@ -18,7 +20,7 @@ trait AsksApplication
 
         $this->showApplications($applications);
 
-        return $this->anticipate('What is the Application ?', $applications->all());
+        return $this->anticipate('What is the Application ?', $this->wrapCallable($applications->all()));
     }
 
     /**
@@ -44,7 +46,7 @@ trait AsksApplication
         return $this->anticipate(
             "You may want {$classname} to live in a sub namespace. Which one ?"
             . ' Leave it empty if you want to leave it in root namespace.',
-            $domains?->all() ?? []
+            $this->wrapCallable($domains?->all() ?? [])
         );
     }
 }

--- a/src/Commands/Concerns/AsksClass.php
+++ b/src/Commands/Concerns/AsksClass.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait AsksClass
 {
+    use WrapsCallable;
+
     /**
      * @param Collection<int, class-string> $classes
      */
@@ -22,7 +24,7 @@ trait AsksClass
 
         $class = $this->anticipate(
             $question,
-            $classes->merge($classes->map(fn (string $class) => class_basename($class)))->sort()->all()
+            $this->wrapCallable($classes->merge($classes->map(fn (string $class) => class_basename($class)))->sort()->all())
         );
 
         if ($classes->contains($class)) {

--- a/src/Commands/Concerns/AsksDTO.php
+++ b/src/Commands/Concerns/AsksDTO.php
@@ -19,7 +19,7 @@ trait AsksDTO
 
         $dto = $this->anticipate(
             'What is the DTO ?',
-            $dtos->merge($dtos->map(fn (string $dto) => class_basename($dto)))->sort()->all()
+            $this->wrapCallable($dtos->merge($dtos->map(fn (string $dto) => class_basename($dto)))->sort()->all())
         );
 
         if ($dtos->contains($dto)) {

--- a/src/Commands/Concerns/AsksDomain.php
+++ b/src/Commands/Concerns/AsksDomain.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait AsksDomain
 {
+    use WrapsCallable;
+
     /**
      * @param \Illuminate\Support\Collection<int, string> $domains
      */
@@ -18,7 +20,7 @@ trait AsksDomain
 
         $this->showDomains($domains);
 
-        return $this->anticipate('What is the Domain ?', $domains->all());
+        return $this->anticipate('What is the Domain ?', $this->wrapCallable($domains->all()));
     }
 
     /**

--- a/src/Commands/Concerns/AsksModel.php
+++ b/src/Commands/Concerns/AsksModel.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait AsksModel
 {
+    use WrapsCallable;
+
     /**
      * @param \Illuminate\Support\Collection<int, class-string<\Illuminate\Database\Eloquent\Model>> $models
      * @return class-string<\Illuminate\Database\Eloquent\Model>
@@ -25,7 +27,7 @@ trait AsksModel
 
         $model = $this->anticipate(
             'What is the Model ?',
-            $models->merge($models->map(fn (string $model) => class_basename($model)))->sort()->all()
+            $this->wrapCallable($models->merge($models->map(fn (string $model) => class_basename($model)))->sort()->all())
         );
 
         if ($models->contains($model)) {

--- a/src/Commands/Concerns/WrapsCallable.php
+++ b/src/Commands/Concerns/WrapsCallable.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Commands\Concerns;
+
+use Closure;
+use function is_callable;
+
+trait WrapsCallable
+{
+    /**
+     * @template TKey of array-key
+     * @template TValue
+     * @param array<TKey, TValue> $array
+     * @return array<TKey, TValue>|Closure(): array<TKey, TValue> $defaults
+     */
+    public function wrapCallable(array $array): array|Closure
+    {
+        if (!is_callable($array)) {
+            return $array;
+        }
+
+        return fn () => $array;
+    }
+}


### PR DESCRIPTION
In some cases, calls to `anticipate` fails with ` Method Some\Class::SomeMethod does not exist.`
for exemple: 
```
Method Illuminate\Auth\SessionGuard::Management does not exist.
```

This can happen when the anticipation array contains 2 elements and the first one is an exiting class :

```php
 $this->anticipate('What is the Application ?', ['Auth', 'Management']);
 ```
 `['Auth', 'Management']` is considered a valid callable and Symfony component tries to call it. 
 
The solution here is to wrap this array in a closure : 
```php
 $this->anticipate('What is the Application ?', fn() => ['Auth', 'Management']);
 ```
