### PR TITLE
Remove $model attribute in factories

### DIFF
--- a/resources/views/factory.blade.php
+++ b/resources/views/factory.blade.php
@@ -1,13 +1,9 @@
 namespace {{ $namespace }};
 
-use {{ $model->class }};
 use {{ $baseClass }};
 
 class {{ $className }} extends {{ $baseClassName }}
 {
-    /** @@var string */
-    protected $model = {{ $model->getName() }}::class;
-
     /**
      * @@return array<string, mixed>
      */

--- a/tests/__snapshots__/files/FactoryCommandTest__it_creates_the_factory_correctly__1.php
+++ b/tests/__snapshots__/files/FactoryCommandTest__it_creates_the_factory_correctly__1.php
@@ -2,14 +2,10 @@
 
 namespace Database\Factories\User;
 
-use Domain\User\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class UserFactory extends Factory
 {
-    /** @var string */
-    protected $model = User::class;
-
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
`$model` attribute can be avoided and was removed in Laravel 9 stub