### PR TITLE
Create unit test depending on tested class

### DIFF
--- a/config/somake.php
+++ b/config/somake.php
@@ -20,6 +20,7 @@ return [
     ],
 
     'test_generators' => [
+        Soyhuce\Somake\Domains\Test\UnitTestGenerators\FormRequestTestGenerator::class,
         Soyhuce\Somake\Domains\Test\UnitTestGenerators\DefaultTestGenerator::class,
     ],
 ];

--- a/config/somake.php
+++ b/config/somake.php
@@ -18,4 +18,8 @@ return [
         'request' => Illuminate\Foundation\Http\FormRequest::class,
         'resource' => Illuminate\Http\Resources\Json\JsonResource::class,
     ],
+
+    'test_generators' => [
+        Soyhuce\Somake\Domains\Test\UnitTestGenerators\DefaultTestGenerator::class,
+    ],
 ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -106,6 +106,16 @@ parameters:
 			path: src/Domains/DocBlock/DocBlock.php
 
 		-
+			message: "#^Unable to resolve the template type TMakeKey in call to method static method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:make\\(\\)$#"
+			count: 1
+			path: src/Domains/Test/UnitTestGenerator.php
+
+		-
+			message: "#^Unable to resolve the template type TMakeValue in call to method static method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:make\\(\\)$#"
+			count: 1
+			path: src/Domains/Test/UnitTestGenerator.php
+
+		-
 			message: "#^Parameter \\#1 \\$view of function view expects view\\-string\\|null, string given\\.$#"
 			count: 2
 			path: src/Support/PendingWriter.php

--- a/resources/views/test-contract.blade.php
+++ b/resources/views/test-contract.blade.php
@@ -1,4 +1,4 @@
-/* @@covers \{{ $coveredClass }}::{{ $coveredMethod }} */
+/* @@covers \{{ $covered }} */
 
 it('respects success contract', function (): void {
     $this->{{ $verb }}Json("{{ $url }}")

--- a/resources/views/test-feature.blade.php
+++ b/resources/views/test-feature.blade.php
@@ -1,4 +1,4 @@
-/* @@covers \{{ $coveredClass }}::{{ $coveredMethod }} */
+/* @@covers \{{ $covered }} */
 
 it('is successful', function (): void {
     $this->{{ $verb }}Json("{{ $url }}")

--- a/resources/views/test-unit-form-request.blade.php
+++ b/resources/views/test-unit-form-request.blade.php
@@ -1,0 +1,13 @@
+/* @@covers \{{ $covered }} */
+
+use {{ $classFqcn }};
+
+it('passes validation', function (): void {
+    $this->createRequest({{ $classBasename }}::class)
+        ->validate([
+@foreach($parameters as $parameter)
+            '{{ $parameter }}' => '',
+@endforeach
+        ])
+        ->assertPasses();
+});

--- a/resources/views/test-unit.blade.php
+++ b/resources/views/test-unit.blade.php
@@ -1,4 +1,4 @@
-/* @@covers \{{ $coveredClass }} */
+/* @@covers \{{ $covered }} */
 
 it('is successful', function (): void {
 });

--- a/src/Contracts/UnitTestGenerator.php
+++ b/src/Contracts/UnitTestGenerator.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Contracts;
+
+/**
+ * @template TClass
+ */
+interface UnitTestGenerator
+{
+    /**
+     * @param class-string $class
+     */
+    public static function shouldHandle(string $class): bool;
+
+    public function view(): string;
+
+    /**
+     * @param class-string<TClass> $class
+     * @return array<string, mixed>
+     */
+    public function data(string $class): array;
+}

--- a/src/Domains/Test/ContractTestGenerator.php
+++ b/src/Domains/Test/ContractTestGenerator.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Domains\Test;
+
+use Soyhuce\Somake\Domains\Request\RouteGuesser;
+
+class ContractTestGenerator
+{
+    public function __construct(
+        public string $controller,
+        public string $method,
+    ) {
+    }
+
+    public function view(): string
+    {
+        return 'test-contract';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function data(): array
+    {
+        $routeGuesser = new RouteGuesser($this->controller, $this->method);
+
+        return [
+            'covered' => "{$this->controller}::{$this->method}",
+            'url' => $routeGuesser->url(),
+            'verb' => $routeGuesser->verb(),
+        ];
+    }
+}

--- a/src/Domains/Test/FeatureTestGenerator.php
+++ b/src/Domains/Test/FeatureTestGenerator.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Domains\Test;
+
+use Soyhuce\Somake\Domains\Request\RouteGuesser;
+
+class FeatureTestGenerator
+{
+    public function __construct(
+        public string $controller,
+        public string $method,
+    ) {
+    }
+
+    public function view(): string
+    {
+        return 'test-feature';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function data(): array
+    {
+        $routeGuesser = new RouteGuesser($this->controller, $this->method);
+
+        return [
+            'covered' => "{$this->controller}::{$this->method}",
+            'url' => $routeGuesser->url(),
+            'verb' => $routeGuesser->verb(),
+        ];
+    }
+}

--- a/src/Domains/Test/UnitTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerator.php
@@ -47,7 +47,7 @@ class UnitTestGenerator
             'covered' => $this->class,
             'classFqcn' => $this->class,
             'classBasename' => class_basename($this->class),
-            ...$this->generator->data($this->class)
+            ...$this->generator->data($this->class),
         ];
     }
 }

--- a/src/Domains/Test/UnitTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerator.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Domains\Test;
+
+use Illuminate\Support\Collection;
+use LogicException;
+use Soyhuce\Somake\Contracts\UnitTestGenerator as UnitTestGeneratorContract;
+
+/**
+ * @template TClass
+ */
+class UnitTestGenerator
+{
+    /** @var \Soyhuce\Somake\Contracts\UnitTestGenerator<TClass> */
+    protected UnitTestGeneratorContract $generator;
+
+    /**
+     * @param class-string<TClass> $class
+     */
+    public function __construct(
+        public string $class,
+    ) {
+        $generatorClass = Collection::make(config('somake.test_generators'))
+            ->each(fn (string $generator) => throw_if(
+                !is_subclass_of($generator, UnitTestGeneratorContract::class),
+                new LogicException("{$generator} must implement UnitTestGenerator")
+            ))
+            ->first(
+                fn (string $generator) => $generator::shouldHandle($this->class),
+                fn () => throw new LogicException("No generator found for {$this->class}")
+            );
+
+        $this->generator = app($generatorClass);
+    }
+
+    public function view(): string
+    {
+        return $this->generator->view();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function data(): array
+    {
+        return $this->generator->data($this->class);
+    }
+}

--- a/src/Domains/Test/UnitTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerator.php
@@ -43,6 +43,11 @@ class UnitTestGenerator
      */
     public function data(): array
     {
-        return $this->generator->data($this->class);
+        return [
+            'covered' => $this->class,
+            'classFqcn' => $this->class,
+            'classBasename' => class_basename($this->class),
+            ...$this->generator->data($this->class)
+        ];
     }
 }

--- a/src/Domains/Test/UnitTestGenerators/DefaultTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerators/DefaultTestGenerator.php
@@ -21,8 +21,6 @@ class DefaultTestGenerator implements UnitTestGenerator
 
     public function data(string $class): array
     {
-        return [
-            'covered' => $class,
-        ];
+        return [];
     }
 }

--- a/src/Domains/Test/UnitTestGenerators/DefaultTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerators/DefaultTestGenerator.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Domains\Test\UnitTestGenerators;
+
+use Soyhuce\Somake\Contracts\UnitTestGenerator;
+
+/**
+ * @implements UnitTestGenerator<mixed>
+ */
+class DefaultTestGenerator implements UnitTestGenerator
+{
+    public static function shouldHandle(string $class): bool
+    {
+        return true;
+    }
+
+    public function view(): string
+    {
+        return 'test-unit';
+    }
+
+    public function data(string $class): array
+    {
+        return [
+            'covered' => $class,
+        ];
+    }
+}

--- a/src/Domains/Test/UnitTestGenerators/FormRequestTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerators/FormRequestTestGenerator.php
@@ -1,9 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Soyhuce\Somake\Domains\Test\UnitTestGenerators;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Collection;
 use Soyhuce\Somake\Contracts\UnitTestGenerator;
 
 class FormRequestTestGenerator implements UnitTestGenerator

--- a/src/Domains/Test/UnitTestGenerators/FormRequestTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerators/FormRequestTestGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Soyhuce\Somake\Domains\Test\UnitTestGenerators;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Collection;
+use Soyhuce\Somake\Contracts\UnitTestGenerator;
+
+class FormRequestTestGenerator implements UnitTestGenerator
+{
+    public static function shouldHandle(string $class): bool
+    {
+        return is_subclass_of($class, FormRequest::class);
+    }
+
+    public function view(): string
+    {
+        return 'test-unit-form-request';
+    }
+
+    public function data(string $class): array
+    {
+        return [
+            'parameters' => array_keys(app()->call([new $class(), 'rules'])),
+        ];
+    }
+}

--- a/test-laravel/app/App/Website/Videos/Requests/UpdateVideoRequest.php
+++ b/test-laravel/app/App/Website/Videos/Requests/UpdateVideoRequest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace App\Website\Videos\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateVideoRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'published_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/tests/Feature/TestCommandTest.php
+++ b/tests/Feature/TestCommandTest.php
@@ -78,3 +78,17 @@ it('creates correctly the unit test', function (): void {
         ->toBeFile()
         ->toMatchFileSnapshot();
 });
+
+
+it('creates correctly the unit test for form request', function (): void {
+    $this->artisan('somake:test')
+        ->expectsQuestion('Which kind of test do you want to create ?', 'Unit')
+        ->expectsQuestion('Which class do you want to cover ?', 'UpdateVideoRequest')
+        ->expectsOutput('The Tests\\Unit\\App\\Website\\Videos\\Requests\\UpdateVideoRequestTest class was successfully created !')
+        ->assertExitCode(0)
+        ->execute();
+
+    expect($this->app->basePath('tests/Unit/App/Website/Videos/Requests/UpdateVideoRequestTest.php'))
+        ->toBeFile()
+        ->toMatchFileSnapshot();
+});

--- a/tests/Feature/TestCommandTest.php
+++ b/tests/Feature/TestCommandTest.php
@@ -79,7 +79,6 @@ it('creates correctly the unit test', function (): void {
         ->toMatchFileSnapshot();
 });
 
-
 it('creates correctly the unit test for form request', function (): void {
     $this->artisan('somake:test')
         ->expectsQuestion('Which kind of test do you want to create ?', 'Unit')

--- a/tests/__snapshots__/files/TestCommandTest__it_creates_correctly_the_unit_test_for_form_request__1.php
+++ b/tests/__snapshots__/files/TestCommandTest__it_creates_correctly_the_unit_test_for_form_request__1.php
@@ -1,0 +1,15 @@
+<?php
+
+/* @covers \App\Website\Videos\Requests\UpdateVideoRequest */
+
+use App\Website\Videos\Requests\UpdateVideoRequest;
+
+it('passes validation', function (): void {
+    $this->createRequest(UpdateVideoRequest::class)
+        ->validate([
+            'title' => '',
+            'description' => '',
+            'published_at' => '',
+        ])
+        ->assertPasses();
+});


### PR DESCRIPTION
This PR opens the ability to define unit test file templates based on tested class.

It includes an example for FormRequest test.

This is an alternative implementation of https://github.com/Soyhuce/laravel-somake/pull/27