### PR TITLE
Remove down in migrations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Command \"somake\\:builder\" does not have option \"model\"\\.$#"
+			count: 2
+			path: src/Commands/BuilderCommand.php
+
+		-
+			message: "#^Left side of && is always false\\.$#"
+			count: 1
+			path: src/Commands/BuilderCommand.php
+
+		-
 			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\BuilderCommand\\:\\:askModel\\(\\) should return class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\> but returns array\\|bool\\|string\\.$#"
 			count: 1
 			path: src/Commands/BuilderCommand.php
@@ -16,7 +26,12 @@ parameters:
 			path: src/Commands/BuilderCommand.php
 
 		-
-			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\FactoryCommand\\:\\:askModel\\(\\) should return class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\> but returns array\\|bool\\|string\\.$#"
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Commands/FactoryCommand.php
+
+		-
+			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\FactoryCommand\\:\\:askModel\\(\\) should return class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\> but returns string\\.$#"
 			count: 1
 			path: src/Commands/FactoryCommand.php
 
@@ -29,6 +44,16 @@ parameters:
 			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\FactoryCommand\\:\\:disambiguateModel\\(\\) should return string but returns array\\|string\\.$#"
 			count: 1
 			path: src/Commands/FactoryCommand.php
+
+		-
+			message: "#^Command \"somake\\:policy\" does not have option \"model\"\\.$#"
+			count: 2
+			path: src/Commands/PolicyCommand.php
+
+		-
+			message: "#^Left side of && is always false\\.$#"
+			count: 1
+			path: src/Commands/PolicyCommand.php
 
 		-
 			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\PolicyCommand\\:\\:askModel\\(\\) should return class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\> but returns array\\|bool\\|string\\.$#"
@@ -61,6 +86,16 @@ parameters:
 			path: src/Commands/RequestCommand.php
 
 		-
+			message: "#^Command \"somake\\:resource\" does not have option \"model\"\\.$#"
+			count: 2
+			path: src/Commands/ResourceCommand.php
+
+		-
+			message: "#^Left side of && is always false\\.$#"
+			count: 1
+			path: src/Commands/ResourceCommand.php
+
+		-
 			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\ResourceCommand\\:\\:askModel\\(\\) should return class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\> but returns array\\|bool\\|string\\.$#"
 			count: 1
 			path: src/Commands/ResourceCommand.php
@@ -76,7 +111,12 @@ parameters:
 			path: src/Commands/ResourceCommand.php
 
 		-
-			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askClass\\(\\) should return class\\-string but returns array\\|bool\\|string\\.$#"
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Commands/TestCommand.php
+
+		-
+			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askClass\\(\\) should return class\\-string but returns string\\.$#"
 			count: 1
 			path: src/Commands/TestCommand.php
 
@@ -86,12 +126,12 @@ parameters:
 			path: src/Commands/TestCommand.php
 
 		-
-			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askType\\(\\) should return string but returns array\\|bool\\|string\\|null\\.$#"
+			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askType\\(\\) should return string but returns array\\|string\\.$#"
 			count: 1
 			path: src/Commands/TestCommand.php
 
 		-
-			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askType\\(\\) should return string but returns array\\|string\\.$#"
+			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\TestCommand\\:\\:askType\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/Commands/TestCommand.php
 

--- a/resources/stubs/migration.create.stub
+++ b/resources/stubs/migration.create.stub
@@ -13,9 +13,4 @@ return new class extends Migration
             $table->timestamps();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('{{ table }}');
-    }
 };

--- a/resources/stubs/migration.stub
+++ b/resources/stubs/migration.stub
@@ -10,9 +10,4 @@ return new class extends Migration
     {
         //
     }
-
-    public function down(): void
-    {
-        //
-    }
 };

--- a/resources/stubs/migration.update.stub
+++ b/resources/stubs/migration.update.stub
@@ -12,11 +12,4 @@ return new class extends Migration
             //
         });
     }
-
-    public function down(): void
-    {
-        Schema::table('{{ table }}', function (Blueprint $table) {
-            //
-        });
-    }
 };

--- a/tests/__snapshots__/files/MigrationCommandTest__it_creates_the_migration_correctly__1.php
+++ b/tests/__snapshots__/files/MigrationCommandTest__it_creates_the_migration_correctly__1.php
@@ -13,9 +13,4 @@ return new class extends Migration
             $table->timestamps();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('tests');
-    }
 };


### PR DESCRIPTION
Down method in migration is generaly poorly tested. It shouldn't be used unless needed and tested.

This PR removes it from generated files.

Fixes #35 