### PR TITLE
Add middleware test generation

### DIFF
--- a/config/somake.php
+++ b/config/somake.php
@@ -21,6 +21,7 @@ return [
     'test_generators' => [
         Soyhuce\Somake\Domains\Test\UnitTestGenerators\FormRequestTestGenerator::class,
         Soyhuce\Somake\Domains\Test\UnitTestGenerators\JsonResourceTestGenerator::class,
+        Soyhuce\Somake\Domains\Test\UnitTestGenerators\MiddlewareTestGenerator::class,
         Soyhuce\Somake\Domains\Test\UnitTestGenerators\DefaultTestGenerator::class,
     ],
 ];

--- a/resources/views/test-unit-middleware.blade.php
+++ b/resources/views/test-unit-middleware.blade.php
@@ -1,0 +1,12 @@
+/* @@covers \{{ $covered }} */
+
+use {{ $classFqcn }};
+use Illuminate\Support\Facades\Route;
+
+it('handles the request', function(): void {
+    Route::get('test', fn() => 'ok')
+        ->middleware({{ $classBasename }}::class);
+
+    $this->get('test')
+        ->assertOk();
+});

--- a/src/Domains/Test/UnitTestGenerators/MiddlewareTestGenerator.php
+++ b/src/Domains/Test/UnitTestGenerators/MiddlewareTestGenerator.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Somake\Domains\Test\UnitTestGenerators;
+
+use Closure;
+use Illuminate\Http\Request;
+use ReflectionClass;
+use ReflectionNamedType;
+use Soyhuce\Somake\Contracts\UnitTestGenerator;
+use function count;
+
+/**
+ * @implements \Soyhuce\Somake\Contracts\UnitTestGenerator<mixed>
+ */
+class MiddlewareTestGenerator implements UnitTestGenerator
+{
+    public static function shouldHandle(string $class): bool
+    {
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        $reflectionClass = new ReflectionClass($class);
+        if (!$reflectionClass->hasMethod('handle')) {
+            return false;
+        }
+
+        $parameters = $reflectionClass->getMethod('handle')->getParameters();
+        if (count($parameters) < 2) {
+            return false;
+        }
+
+        if (!$parameters[0]->getType() instanceof ReflectionNamedType || $parameters[0]->getType()->getName() !== Request::class) {
+            return false;
+        }
+
+        if (!$parameters[1]->getType() instanceof ReflectionNamedType || $parameters[1]->getType()->getName() !== Closure::class) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function view(): string
+    {
+        return 'test-unit-middleware';
+    }
+
+    public function data(string $class): array
+    {
+        return [];
+    }
+}

--- a/test-laravel/tests/Unit/Support/Http/Middleware/PreventRequestsDuringMaintenanceTest.php
+++ b/test-laravel/tests/Unit/Support/Http/Middleware/PreventRequestsDuringMaintenanceTest.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+
+/* @covers \Support\Http\Middleware\PreventRequestsDuringMaintenance */
+
+it('is successful', function (): void {
+});

--- a/tests/Feature/TestCommandTest.php
+++ b/tests/Feature/TestCommandTest.php
@@ -104,3 +104,16 @@ it('creates correctly the unit test for json resource', function (): void {
         ->toBeFile()
         ->toMatchFileSnapshot();
 });
+
+it('creates correctly the unit test for middleware', function (): void {
+    $this->artisan('somake:test')
+        ->expectsQuestion('Which kind of test do you want to create ?', 'Unit')
+        ->expectsQuestion('Which class do you want to cover ?', 'RedirectIfAuthenticated')
+        ->expectsOutput('The Tests\\Unit\\Support\\Http\\Middleware\\RedirectIfAuthenticatedTest class was successfully created !')
+        ->assertExitCode(0)
+        ->execute();
+
+    expect($this->app->basePath('tests/Unit/Support/Http/Middleware/RedirectIfAuthenticatedTest.php'))
+        ->toBeFile()
+        ->toMatchFileSnapshot();
+});

--- a/tests/__snapshots__/files/TestCommandTest__it_creates_correctly_the_unit_test_for_middleware__1.php
+++ b/tests/__snapshots__/files/TestCommandTest__it_creates_correctly_the_unit_test_for_middleware__1.php
@@ -1,0 +1,14 @@
+<?php
+
+/* @covers \Support\Http\Middleware\RedirectIfAuthenticated */
+
+use Support\Http\Middleware\RedirectIfAuthenticated;
+use Illuminate\Support\Facades\Route;
+
+it('handles the request', function(): void {
+    Route::get('test', fn() => 'ok')
+        ->middleware(RedirectIfAuthenticated::class);
+
+    $this->get('test')
+        ->assertOk();
+});


### PR DESCRIPTION
Creates a test like 

```php
<?php

/* @covers \Support\Http\Middleware\RedirectIfAuthenticated */

use Support\Http\Middleware\RedirectIfAuthenticated;
use Illuminate\Support\Facades\Route;

it('handles the request', function(): void {
    Route::get('test', fn() => 'ok')
        ->middleware(RedirectIfAuthenticated::class);

    $this->get('test')
        ->assertOk();
});
```

for the middlewares