### PR TITLE
Fix disambiguations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,7 +31,7 @@ parameters:
 			path: src/Commands/BuilderCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
 			count: 1
 			path: src/Commands/BuilderCommand.php
 
@@ -56,7 +56,7 @@ parameters:
 			path: src/Commands/FactoryCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
 			count: 1
 			path: src/Commands/FactoryCommand.php
 
@@ -76,7 +76,7 @@ parameters:
 			path: src/Commands/ListenerCommand.php
 
 		-
-			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\ListenerCommand\\:\\:disambiguateClass\\(\\) should return string but returns int\\|string\\.$#"
+			message: "#^Method Soyhuce\\\\Somake\\\\Commands\\\\ListenerCommand\\:\\:disambiguateEvent\\(\\) should return string but returns int\\|string\\.$#"
 			count: 1
 			path: src/Commands/ListenerCommand.php
 
@@ -86,7 +86,7 @@ parameters:
 			path: src/Commands/ListenerCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\> given\\.$#"
 			count: 1
 			path: src/Commands/ListenerCommand.php
 
@@ -126,7 +126,7 @@ parameters:
 			path: src/Commands/PolicyCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
 			count: 1
 			path: src/Commands/PolicyCommand.php
 
@@ -156,7 +156,7 @@ parameters:
 			path: src/Commands/RequestCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\<Spatie\\\\LaravelData\\\\Data\\>\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\<Spatie\\\\LaravelData\\\\Data\\>\\> given\\.$#"
 			count: 1
 			path: src/Commands/RequestCommand.php
 
@@ -191,7 +191,7 @@ parameters:
 			path: src/Commands/ResourceCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\> given\\.$#"
 			count: 1
 			path: src/Commands/ResourceCommand.php
 
@@ -226,7 +226,7 @@ parameters:
 			path: src/Commands/TestCommand.php
 
 		-
-			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<int, class\\-string\\> given\\.$#"
+			message: "#^Parameter \\$options of function Laravel\\\\Prompts\\\\select expects array\\<int\\|string, string\\>\\|Illuminate\\\\Support\\\\Collection\\<int\\|string, string\\>, Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), class\\-string\\> given\\.$#"
 			count: 1
 			path: src/Commands/TestCommand.php
 

--- a/src/Commands/Concerns/AsksClass.php
+++ b/src/Commands/Concerns/AsksClass.php
@@ -82,7 +82,7 @@ trait AsksClass
 
         return select(
             label: 'Which one should I choose ?',
-            options: $guessedClasses
+            options: $guessedClasses->keyBy(fn (string $fqcn) => $fqcn)
         );
     }
 }

--- a/src/Commands/Concerns/AsksData.php
+++ b/src/Commands/Concerns/AsksData.php
@@ -76,7 +76,7 @@ trait AsksData
 
         return select(
             label: 'Which one should I choose ?',
-            options: $datas
+            options: $datas->keyBy(fn (string $fqcn) => $fqcn)
         );
     }
 }

--- a/src/Commands/Concerns/AsksEvent.php
+++ b/src/Commands/Concerns/AsksEvent.php
@@ -50,7 +50,7 @@ trait AsksEvent
         return match ($guessedEvents->count()) {
             0 => $this->qualifyEvent($question, $event),
             1 => $guessedEvents->first(),
-            default => $this->disambiguateClass($guessedEvents)
+            default => $this->disambiguateEvent($guessedEvents)
         };
     }
 
@@ -71,15 +71,15 @@ trait AsksEvent
     }
 
     /**
-     * @param \Illuminate\Support\Collection<int, class-string> $guessedClasses
+     * @param \Illuminate\Support\Collection<int, class-string> $guessedEvents
      */
-    private function disambiguateClass(Collection $guessedClasses): string
+    private function disambiguateEvent(Collection $guessedEvents): string
     {
         warning('I\'m not sure which class you choose...');
 
         return select(
             label: 'Which one should I choose ?',
-            options: $guessedClasses
+            options: $guessedEvents->keyBy(fn (string $fqcn) => $fqcn)
         );
     }
 }

--- a/src/Commands/Concerns/AsksModel.php
+++ b/src/Commands/Concerns/AsksModel.php
@@ -77,7 +77,7 @@ trait AsksModel
 
         return select(
             label: 'Which one should I choose ?',
-            options: $models,
+            options: $models->keyBy(fn (string $fqcn) => $fqcn),
         );
     }
 }

--- a/test-laravel/app/App/Admin/Controllers/InvokableVideoController.php
+++ b/test-laravel/app/App/Admin/Controllers/InvokableVideoController.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace App\Admin\Controllers;
+
+class InvokableVideoController
+{
+    public function index(): void
+    {
+    }
+}

--- a/tests/Feature/TestCommandTest.php
+++ b/tests/Feature/TestCommandTest.php
@@ -53,6 +53,8 @@ it('creates correctly the feature test with invokable controller', function (): 
     $this->artisan('somake:test')
         ->expectsQuestion('Which kind of test do you want to create ?', 'Feature')
         ->expectsQuestion('Which controller do you want to cover ?', 'InvokableVideoController')
+        ->expectsOutputToContain('I\'m not sure which class you choose...')
+        ->expectsQuestion('Which one should I choose ?', 'App\\Website\\Videos\\Controllers\\InvokableVideoController')
         ->expectsQuestion('Which method do you want to cover ?', '__invoke')
         ->expectsQuestion('What is the Test name ?', 'IndexVideosTest')
         ->expectsOutputToContain('The Tests\\Feature\\Website\\Videos\\InvokableVideoController\\IndexVideosTest class was successfully created !')


### PR DESCRIPTION
Select returns the key of the element in the options, not it's value.

Fixes #44 

@qanvo Can you check this fix using `composer require --dev soyhuce/laravel:somake:dev-fix_disambiguations` ?